### PR TITLE
Use GraphQl Specs and Require Authentication

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 # GraphiQL.NET Auth
 
-GraphiQL middleware for ASP.NET Core with JWT- bearer token retireval built in. Forked from https://github.com/JosephWoodward/graphiql-dotnet. Either you can paste in a bearer token received from your auth, or you can pass user credentials to your authorization endpoint. This fork does not handle the authorization process in GraphQl or your API.
+GraphiQL middleware for ASP.NET Core with JWT-bearer token retireval built in. Forked from https://github.com/JosephWoodward/graphiql-dotnet. Either you can paste in a bearer token received from your auth, or you can pass user credentials to your authorization mutation. This fork does not handle the authorization process in GraphQl or your API.
 
 ## What is GraphiQL?
 
@@ -79,15 +79,28 @@ Now navigating to `/graphql` will display the GraphiQL UI, but your GraphQL API 
 
 ## Auth Configuration
 
-You can specify an authorization url to request a bearer token from. Note: This fork only supports user credentials (username and password). Feel free to fork and expand my solution for your needs.
+You can specify an authorization mutation to request a bearer token from. When specified users will be able to request a bearer token through the graphql API. In order for this behavior to work the graphql API must have the specified mutation setup.
+
 
 ```csharp
 public void Configure(IApplicationBuilder app, IHostingEnvironment env, ILoggerFactory loggerFactory)
 {
-    app.UseGraphiQl("/graphql", "/v1/yourapi", "https://authorizationurl/v1/token");
+    app.UseGraphiQl("/graphql", "/v1/yourapi", "login");
 
     app.UseMvc();
 }
 ```
+
+Now navigating to `/graphql` will display the GraphiQL UI, but your GraphQL API will include an additional login area at the top of the screen. After a successsful login the bearer token will appear in this area.
+
+All future graphql requeusts you make will include the token displayed in the login area. If you do not wish to login through user credentials, a valid bearer token may be copied into the login area.
+
+### Specifications
+
+- This fork only supports user credentials (username and password) when logging in. Feel free to fork and expand my solution for your needs.
+- The bearer token displayed in the login area will be included in the request header. It is up to you to utilize that in your graphql API.
+- The auth mutation must be part of the graphql API that you configured above.
+- The auth mutation must support `accessToken` in it's return type.
+- The auth mutation MAY support `expires` in it's return type. When supported, the access token will be stored as a cookie for the `expires` duration.
 
 

--- a/src/graphiql/GraphiQlExtensions.cs
+++ b/src/graphiql/GraphiQlExtensions.cs
@@ -19,15 +19,16 @@ namespace GraphiQl
 
         /// <param name="path"></param>
         /// <param name="apiPath">In some scenarios it makes sense to specify the API path and file server path independently
+        /// <param name="authMutation">The mutation to use for the authorization. Typically this will be 'login'.</param>
         /// Examples: hosting in IIS in a virtual application (myapp.com/1.0/...) or hosting API and documentation separately</param>
-        public static IApplicationBuilder UseGraphiQl(this IApplicationBuilder app, string path, string apiPath, string authUrl = null)
+        public static IApplicationBuilder UseGraphiQl(this IApplicationBuilder app, string path, string apiPath, string authMutation = null)
         {
             if (string.IsNullOrWhiteSpace(path))
                 throw new ArgumentException(nameof(path));
 
             var filePath = path.EndsWith("/") ? path : $"{path}/" + "graphql-path.js";
             var uri = !string.IsNullOrWhiteSpace(apiPath) ? apiPath : path;
-            app.Map(filePath, x => WritePathJavaScript(x, uri, authUrl));
+            app.Map(filePath, x => WritePathJavaScript(x, uri, authMutation));
 
             return UseGraphiQlImp(app, x => x.SetPath(path));
         }
@@ -67,12 +68,12 @@ namespace GraphiQl
             return fileProvider;
         }
 
-        private static void WritePathJavaScript(IApplicationBuilder app, string path, string authUrl = null)
+        private static void WritePathJavaScript(IApplicationBuilder app, string path, string authMutation = null)
         {
             app.Run(h =>
             {
                 h.Response.ContentType = "application/javascript";
-                return h.Response.WriteAsync($"var graphqlPath='{path}'; var authUrl='{authUrl}'");
+                return h.Response.WriteAsync($"var graphqlPath='{path}'; var authMutation='{authMutation}'");
             });
         }
     }

--- a/src/graphiql/assets/index.html
+++ b/src/graphiql/assets/index.html
@@ -98,7 +98,7 @@
         <script src="./graphql-path.js"></script>
     </head>
     <body>
-        <button class="collapsible"><i class="arrow down"></i></button>
+        <button id="jwt-token-collapsible-area" class="collapsible" style="display: none;"><i class="arrow down"></i></button>
         <div class="jwt-token">
             <div class="token">
                 <button id="loginBtn">Refresh Token</button>
@@ -113,64 +113,92 @@
         <div id="graphiql">Loading...</div>
         <script>
             // Collapsable Bearer Section
-            var coll = document.getElementsByClassName("collapsible");
-            for (var count = 0; count < coll.length; count++) {
-                coll[count].addEventListener("click", function () {
-                    this.classList.toggle("active");
-                    var content = this.nextElementSibling;
-                    if (content.style.maxHeight) {
-                        content.style.maxHeight = null;
-                        content.style.padding = null;
-                    } else {
-                        content.style.maxHeight = content.scrollHeight + "px";
-                        content.style.padding = "7px 14px 6px";
-                    }
-                });
+            if (authMutation) {
+                document.getElementById('jwt-token-collapsible-area').style.display = "block";
+                var coll = document.getElementsByClassName("collapsible");
+                for (var count = 0; count < coll.length; count++) {
+                    coll[count].addEventListener("click", function () {
+                        this.classList.toggle("active");
+                        var content = this.nextElementSibling;
+                        if (content.style.maxHeight) {
+                            content.style.maxHeight = null;
+                            content.style.padding = null;
+                        } else {
+                            content.style.maxHeight = content.scrollHeight + "px";
+                            content.style.padding = "7px 14px 6px";
+                        }
+                    });
+                }
             }
 
             // Login to refresh bearer token
+            var loggedIn = false;
             var login = document.getElementById("loginBtn");
             login.addEventListener("click", function () {
+                if (authMutation === null) {
+                    alert('The authorization mutation was not found');
+                    return;
+                }
+
                 var username = document.getElementById('username').value;
                 var password = document.getElementById('password').value;
-
-                callLoginAPI(username, password);
-            });
-
-            function callLoginAPI(username, password) {
-                const config = {
-                    method: 'POST',
-                    headers: {
-                        'Content-Type': 'application/x-www-form-urlencoded',
-                        accept: 'application/json'
-                    },
-                    credentials: 'same-origin',
-                    body: `username=${username}&password=${password}&grant_type=password`
-                };
 
                 if (username.length < 1 || password.length < 1) {
                     alert('Username and password cannot be empty.');
                     return;
                 }
 
-                return fetch(authUrl, config).then(function (response) {
-                    return response.text();
-                }).then(function (responseBody) {
+                var graphQLAuthParams = {
+                    query: 'mutation {\n  ' + authMutation + '(input: {username: "' + username + '", password: "' + password + '"}) {\n    accessToken\n    expires\n  }\n}\n',
+                    variables: null
+                };
+                
+                var queryPromise = reactElement.props.fetcher(graphQLAuthParams);
+                queryPromise.then(function (result) {
                     try {
-                        var token = JSON.parse(responseBody).access_token;
+                        var response = result.data[authMutation];
 
-                        if (token) {
-                            document.getElementById('jwt-token').value = token;
-                            localStorage.setItem('graphiql:jwtToken', token);
+                        var token = response.accessToken;
+                        var expiration = response.expires;
+
+                        if (token === null) {
+                            throw ("No token was returned.");
+                        }
+                        document.getElementById('jwt-token').value = token;
+
+                        if (expiration) {
+                            var date = new Date(expiration)
+                            document.cookie = "token=" + token + "; expires=" + date.toGMTString();
                         }
                         else {
-                            alert("Invalid Credentials.");
+                            document.cookie = "token=" + token;
+                        }
+
+                        if (loggedIn === false) {
+                            updateFetcher(graphQLAuthorizedFetcher);
+                            loggedIn = true;
                         }
                     } catch (error) {
-                        alert(responseBody);
+                        alert("Error while attempting to login.");
                     }
                 });
-            };
+            });            
+
+            function getCookie(cname) {
+                var name = cname + "=";
+                var decodedCookie = decodeURIComponent(document.cookie);
+                var cookies = decodedCookie.split(';');
+                for (var i = 0; i < cookies.length; i++) {
+                    var cookie = cookies[i];
+                    while (cookie.charAt(0) == ' ') {
+                        cookie = cookie.substring(1);
+                    }
+                    if (cookie.indexOf(name) == 0) {
+                        return cookie.substring(name.length, cookie.length);
+                    }
+                }
+                return "";
+            }
 
             /**
              * This GraphiQL example illustrates how to use some of GraphiQL's props
@@ -191,7 +219,8 @@
                         decodeURIComponent(entry.slice(eq + 1));
                 }
             });
-            document.getElementById('jwt-token').value = localStorage.getItem('graphiql:jwtToken');
+
+            document.getElementById('jwt-token').value = getCookie("token");
 
             // if variables was provided, try to format it.
             if (parameters.variables) {
@@ -231,22 +260,26 @@
                 history.replaceState(null, null, newSearch);
             }
 
-            // Defines a GraphQL fetcher using the fetch API. You're not required to
-            // use fetch, and could instead implement graphQLFetcher however you like,
-            // as long as it returns a Promise or Observable.
-            function graphQLFetcher(graphQLParams) {
-                const jwtToken = document.getElementById('jwt-token').value;
+            function graphQLAuthorizedFetcher(graphQLParams) {
                 let headers = {
                     'Accept': 'application/json',
                     'Content-Type': 'application/json'
                 };
-                if (jwtToken) {
-                    localStorage.setItem('graphiql:jwtToken', jwtToken);
-                    headers = {
-                        'Accept': 'application/json',
-                        'Content-Type': 'application/json',
-                        'Authorization': jwtToken ? `Bearer ${jwtToken}` : null
-                    };
+
+                if (authMutation) {
+                    const jwtToken = document.getElementById('jwt-token').value;
+                    if (jwtToken) {
+                        headers = {
+                            'Accept': 'application/json',
+                            'Content-Type': 'application/json',
+                            'Authorization': `Bearer ${jwtToken}`
+                        };
+                    }
+                    else {
+                        loggedIn = false;
+                        updateFetcher(graphQLUnauthorizedFetcher);
+                        return graphQLUnauthorizedFetcher(graphQLParams);
+                    }
                 }
 
                 // This example expects a GraphQL server at the path /graphql.
@@ -260,6 +293,20 @@
                     return response.text();
                 }).then(function (responseBody) {
                     try {
+                        let errors = JSON.parse(responseBody).errors;
+                        if (errors) {
+                            let i = 0;
+                            while (i < errors.length) {
+                                if (errors[i++].extensions.code === "UNAUTHORIZED_ACCESS") {
+                                    i = errors.length;
+
+                                    loggedIn = false;
+                                    document.getElementById('jwt-token').value = "";
+                                    updateFetcher(graphQLUnauthorizedFetcher);
+                                }
+                            }
+                        }
+
                         return JSON.parse(responseBody);
                     } catch (error) {
                         return responseBody;
@@ -267,22 +314,72 @@
                 });
             }
 
-            // Render <GraphiQL /> into the body.
-            // See the README in the top level of this module to learn more about
-            // how you can customize GraphiQL by providing different values or
-            // additional child elements.
-            ReactDOM.render(
-                React.createElement(GraphiQL, {
-                    fetcher: graphQLFetcher,
+            // Defines a GraphQL fetcher using the fetch API. You're not required to
+            // use fetch, and could instead implement graphQLFetcher however you like,
+            // as long as it returns a Promise or Observable.
+            function graphQLUnauthorizedFetcher(graphQLParams) {
+                if (authMutation) {
+                    const jwtToken = document.getElementById('jwt-token').value;
+                    if (jwtToken) {
+                        loggedIn = true;
+                        updateFetcher(graphQLAuthorizedFetcher);
+                        return graphQLAuthorizedFetcher(graphQLParams);
+                    }
+
+                    if (!graphQLParams.query.includes(authMutation)) {
+                        var loginRequiredPromise = new Promise(function (reject) {
+                            reject("Login is required before using GraphiQl features.");
+                        });
+
+                        return loginRequiredPromise;
+                    }
+                }
+
+                let headers = {
+                    'Accept': 'application/json',
+                    'Content-Type': 'application/json'
+                };
+                
+                // This example expects a GraphQL server at the path /graphql.
+                // Change this to point wherever you host your GraphQL server.
+                return fetch(graphqlPath, {
+                    method: 'post',
+                    headers,
+                    body: JSON.stringify(graphQLParams),
+                }).then(function (response) {
+                    return response.text();
+                }).then(function (responseBody) {
+                    try {
+                        return JSON.parse(responseBody);
+                    } catch (error) {
+                        return responseBody;
+                    }
+                });
+            }
+
+            var reactElement;
+            function updateFetcher(fetcher) {
+                if (reactElement && reactElement.props && reactElement.props.fetcher === fetcher) {
+                    return;
+                }
+
+                // Render <GraphiQL /> into the body.
+                // See the README in the top level of this module to learn more about
+                // how you can customize GraphiQL by providing different values or
+                // additional child elements.
+                reactElement = React.createElement(GraphiQL, {
+                    fetcher: fetcher,
                     query: parameters.query,
                     variables: parameters.variables,
                     operationName: parameters.operationName,
                     onEditQuery: onEditQuery,
                     onEditVariables: onEditVariables,
                     onEditOperationName: onEditOperationName
-                }),
-                document.getElementById('graphiql')
-            );
+                });
+                ReactDOM.render(reactElement, document.getElementById('graphiql'));
+            }
+
+            updateFetcher(authMutation && getCookie("token") === "" ? graphQLUnauthorizedFetcher : graphQLAuthorizedFetcher);
         </script>
     </body>
 </html>

--- a/src/graphiql/graphiql.csproj
+++ b/src/graphiql/graphiql.csproj
@@ -15,9 +15,11 @@
     <Company>Paradigm</Company>
     <Copyright></Copyright>
     <Product>GraphiQLAuth</Product>
-    <Version>1.0.2</Version>
+    <Version>1.1.0</Version>
     <RootNamespace>graphiql</RootNamespace>
-    <PackageReleaseNotes>Correct issue with hidden Variables pane.</PackageReleaseNotes>
+    <PackageReleaseNotes>Convert payload to GraphQl specs.
+Don't allow requests to API until after a token is supplied.</PackageReleaseNotes>
+    <RepositoryUrl>https://github.com/mymatthew/graphiql-dotnet</RepositoryUrl>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="Microsoft.AspNetCore.Mvc" Version="2.0.1" />


### PR DESCRIPTION
Use GraphQl mutation instead of API endpoint,
Require authorization before showing schema in Doc Explorer,
Require authorization to send a query,
Update readme