### PR TITLE
Add in null checks

### DIFF
--- a/src/graphiql/assets/index.html
+++ b/src/graphiql/assets/index.html
@@ -297,7 +297,7 @@
                         if (errors) {
                             let i = 0;
                             while (i < errors.length) {
-                                if (errors[i++].extensions.code === "UNAUTHORIZED_ACCESS") {
+                                if (errors[i].extensions && errors[i].extensions.code && errors[i++].extensions.code === "UNAUTHORIZED_ACCESS") {
                                     i = errors.length;
 
                                     loggedIn = false;


### PR DESCRIPTION
Add in null checks when checking the response body for unauthorized access. This allows the response to be parsed and shown to the user.